### PR TITLE
CI: OVN and OVS scheduled coverage tests.

### DIFF
--- a/.github/workflows/ovn-ovs-coverage.yml
+++ b/.github/workflows/ovn-ovs-coverage.yml
@@ -1,0 +1,47 @@
+name: OVN and OVS coverage
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Run workflows weekly, 02:21 every Tuesday
+    - cron: "21 2 * * 3"
+
+jobs:
+  coverage:
+    runs-on: [self-hosted, amd64, tiobe, noble]
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ["ovn", "ovs"]
+
+    name: "${{ matrix.project }}: Build and test with coverage"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt install -yqq just
+
+      - name: Run tests with coverage
+        run: |
+          just bootstrap ${{ matrix.project }}
+          just cover ${{ matrix.project }}
+
+      - name: Upload unit test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.project }}_unit_test_coverage
+          path: .coverage/cobertura.xml
+          include-hidden-files: true
+
+      - name: Upload coverage report to TIOBE TICS
+        uses: tiobe/tics-github-action@v3
+        env:
+          TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
+        with:
+          mode: qserver
+          project: ${{ matrix.project }}
+          branchdir: "${{ github.workspace }}/workspace/${{ matrix.project }}/"
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+workspace/
+.coverage/
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,57 @@
 
 Automatic validation of binary artifacts maintained by the Ubuntu OVN
 Engineering team.
+
+## Usage
+
+While the main purpose of this repository is to run automatic CI workflows,
+bulk of the logic is implemented in the `justfile` and can be executed
+locally.
+
+To see the list of available recipes, run:
+
+```shell
+just
+```
+
+### Getting test coverage for OVS/OVN
+
+Both [OVN](https://github.com/ovn-org/ovn) and
+[OVS](https://github.com/openvswitch/ovs) share the same workflow fo getting
+the test coverage. We will work with `ovn` in this example.
+
+The first step is to bootstrap the project. This will check out the current
+code from the `main` branch of the project into `./workspace/<project>/`,
+configure the project for compilation with coverage, and install build/test
+dependencies.
+
+```shell
+just bootstrap ovn
+```
+
+(Optional) If you are, at this point, interested only in building the project,
+you can run:
+
+```shell
+just build ovn
+```
+
+Finally, to get the coverage report you can run:
+
+```shell
+just cover ovn
+```
+
+This step will run unit tests and output two types of coverage reports. One is
+the native `lcov` report produced in `./workspace/ovn/tests/lcov/`, and the
+other is the `cobertura` XML file in `.coverage/cobertura.xml`
+
+To clean up the workspace afterwards, you can run
+
+```shell
+just clean [project]
+```
+
+Omitting the `project` parameter will remove the entire `./workspace`
+directory.
+

--- a/justfile
+++ b/justfile
@@ -1,0 +1,73 @@
+ovn_repo := "https://github.com/ovn-org/ovn.git"
+ovs_repo := "https://github.com/openvswitch/ovs.git"
+
+apt_deps := "make gcc libssl-dev libunbound-dev autoconf automake libtool lcov pipx python3-scapy"
+
+# gcovr from apt can't process files with more than 10000 lines. Once the
+# version 7.2 is available from apt, we can drop the whole pipx workflow.
+#
+# https://github.com/gcovr/gcovr/issues/882
+pipx_deps := "gcovr"
+
+@_default:
+	just --list --unsorted
+
+_clone REPO TARGET:
+	mkdir -p workspace
+	git clone --depth 1 --recurse-submodules --shallow-submodules {{REPO}} ./workspace/{{TARGET}}
+
+_deps:
+	sudo apt install -yqq {{apt_deps}}
+	pipx ensurepath
+	pipx install {{pipx_deps}}
+
+@_check_project PROJECT:
+	if [ "{{PROJECT}}" != "ovn" ] && [ "{{PROJECT}}" != "ovs" ]; then echo "Unknown project: {{PROJECT}}"; return 1; fi
+
+_bootstrap-ovn: (_clone ovn_repo "ovn") (_deps)
+	#!/usr/bin/env bash
+	set -exuo pipefail
+	cd workspace/ovn
+	pushd ./ovs/
+	./boot.sh
+	./configure --enable-ssl
+	make -j$(nproc)
+	popd
+	./boot.sh
+	CFLAGS='-fprofile-update=atomic' ./configure --with-ovs-source=./ovs --enable-ssl --enable-coverage
+
+_bootstrap-ovs: (_clone ovs_repo "ovs") (_deps)
+	#!/usr/bin/env bash
+	set -exuo pipefail
+	cd workspace/ovs
+	./boot.sh
+	CFLAGS='-fprofile-update=atomic' ./configure --enable-ssl --enable-coverage
+
+# List avaialble projects
+@list-projects:
+	echo "Supported projects:\n  * ovs\n  * ovn"
+
+# Set up the selected project for the first time
+@bootstrap PROJECT: (_check_project PROJECT)
+	just _bootstrap-{{PROJECT}}
+
+# Build the selected project (requires bootstrap first)
+build PROJECT: (_check_project PROJECT)
+	cd workspace/{{PROJECT}} && make -j$(nproc)
+
+# Run unit tests with coverage in the selected project (requires bootstrap first)
+cover PROJECT: (_check_project PROJECT) (build PROJECT)
+	cd workspace/{{PROJECT}} && make check-lcov TESTSUITEFLAGS="-j$(nproc)"
+	mkdir -p .coverage
+	# Run gcovr from the pipx PATH
+	#
+	# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080 about the need to have
+	# suspicious_hits.warn option. Even though we compile projects with '-fprofile-update=atomic',
+	# the gcovr errro still shows up for the OVS project.
+	~/.local/bin/gcovr -r workspace/{{PROJECT}} --gcov-ignore-parse-errors=suspicious_hits.warn \
+		--merge-mode-functions=merge-use-line-min --cobertura ./.coverage/cobertura.xml
+
+# Cleanup selected project, or all projects (default) in the workspace
+clean PROJECT="":
+	rm -rf ./workspace/{{PROJECT}}
+


### PR DESCRIPTION
CI: OVN and OVS scheduled coverage tests.

This PR adds automatic CI workflows that run every Tuesday at 02:21, and execute unit tests with coverage on the `main` branch of OVN and OVS repository. Results of the coverage run are uploaded to their respective TIOBE TICS projects.

Logic to get the repositories, install dependencies, configure, build and test the projects is implemented in the `justfile`. For more info see README.md
