### PR TITLE
cover: Move cobertura.xml file into project dir

### DIFF
--- a/.github/workflows/ovn-ovs-coverage.yml
+++ b/.github/workflows/ovn-ovs-coverage.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.project }}_unit_test_coverage
-          path: .coverage/cobertura.xml
+          path: ./workspace/${{ matrix.project }}/.coverage/cobertura.xml
           include-hidden-files: true
 
       - name: Upload coverage report to TIOBE TICS

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ just cover ovn
 
 This step will run unit tests and output two types of coverage reports. One is
 the native `lcov` report produced in `./workspace/ovn/tests/lcov/`, and the
-other is the `cobertura` XML file in `.coverage/cobertura.xml`
+other is the `cobertura` XML file in `./workspace/ovn/.coverage/cobertura.xml`
 
 To clean up the workspace afterwards, you can run
 

--- a/justfile
+++ b/justfile
@@ -58,14 +58,14 @@ build PROJECT: (_check_project PROJECT)
 # Run unit tests with coverage in the selected project (requires bootstrap first)
 cover PROJECT: (_check_project PROJECT) (build PROJECT)
 	cd workspace/{{PROJECT}} && make check-lcov TESTSUITEFLAGS="-j$(nproc)"
-	mkdir -p .coverage
+	mkdir -p ./workspace/{{PROJECT}}/.coverage
 	# Run gcovr from the pipx PATH
 	#
 	# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080 about the need to have
 	# suspicious_hits.warn option. Even though we compile projects with '-fprofile-update=atomic',
 	# the gcovr errro still shows up for the OVS project.
 	~/.local/bin/gcovr -r workspace/{{PROJECT}} --gcov-ignore-parse-errors=suspicious_hits.warn \
-		--merge-mode-functions=merge-use-line-min --cobertura ./.coverage/cobertura.xml
+		--merge-mode-functions=merge-use-line-min --cobertura ./workspace/{{PROJECT}}/.coverage/cobertura.xml
 
 # Cleanup selected project, or all projects (default) in the workspace
 clean PROJECT="":


### PR DESCRIPTION
Due to tweaks of the project config on the TIOBE side, the cobertura.xml file is now expected in the 'workspace/<project>/.coverage'.