### PR TITLE
justfile: Add "bump" recipe

### DIFF
--- a/.bump
+++ b/.bump
@@ -1,0 +1,7 @@
+# This file is maintained by `just bump`
+# Github repositories need activity at least every 60 days to keep
+# scheduled workflows active [0]. Update, commit and push changes to
+# this file if there was no organic activity, to keep our regular CI
+# jobs alive.
+# [0] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+75c28793-f029-489b-8a63-be4383bcec94

--- a/justfile
+++ b/justfile
@@ -71,3 +71,16 @@ cover PROJECT: (_check_project PROJECT) (build PROJECT)
 clean PROJECT="":
 	rm -rf ./workspace/{{PROJECT}}
 
+# Update .bump file
+@bump:
+	echo '{{ \
+		"# This file is maintained by `just bump`\n" + \
+		"# Github repositories need activity at least every 60 days to keep\n" + \
+		"# scheduled workflows active [0]. Update, commit and push changes to\n" + \
+		"# this file if there was no organic activity, to keep our regular CI\n" + \
+		"# jobs alive.\n" + \
+		"# [0] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule" \
+        }}' > .bump
+	uuidgen >> .bump
+	echo ".bump file updated."
+


### PR DESCRIPTION
This recipe is just a helper for generating activity for the repository, and preventing deactivation of our scheduled CI workflows. Without any acitvity in the repository in 60 days, scheduled workflows get deactivated [0].

[0] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule